### PR TITLE
Implement the ATtiny's UART Protocol in Python

### DIFF
--- a/raspibot/Serial.py
+++ b/raspibot/Serial.py
@@ -17,10 +17,10 @@ ENCODERS_RESET_RIGHT = b'\x05'
 ENCODERS_RESET_LEFT = b'\x06'
 ENCODERS_RESET_BOTH = b'\x07'
 
+STOP_MOTORS = b'\x21'
 SET_LEFT_MOTOR = b'\x29'
 SET_RIGHT_MOTOR = b'\x25'
 SET_BOTH_MOTORS = b'\x2D'
-STOP_MOTORS = b'\x21'
 
 # Responses
 ACK = b'\x10'
@@ -116,6 +116,19 @@ class AttinyProtocol(object):
     def alive(self):
         """Request an 'alive' signal from the microcontroller."""
         self._serial.write(ALIVE)
+        response = self._serial.read(1)
+        if response == ACK:
+            return True
+        # empty response can happen on a timeout, which we interpret as
+        # "not alive"
+        elif response == NAK or response == b'':
+            return False
+        else:
+            raise InvalidResponseException()
+
+    def stop_motors(self):
+        """Immediately stops both motors."""
+        self._serial.write(STOP_MOTORS)
         response = self._serial.read(1)
         if response == ACK:
             return True

--- a/raspibot/Serial.py
+++ b/raspibot/Serial.py
@@ -1,0 +1,25 @@
+"""Implements the serial interface protocol of RaspiBot's Attiny firmware."""
+
+from collections import namedtuple
+
+EncoderValues = namedtuple('EncoderValues', 'left right')
+
+# Named byte values for the protocol commands
+ENCODERS_BOTH = b'\x04'
+
+
+class AttinyProtocol(object):
+    """Provides methods for protocol transactions."""
+
+    def __init__(self, serial):
+        """Create a protocol instance on a serial interface."""
+        super(AttinyProtocol, self).__init__()
+        self._serial = serial
+
+    def get_encoders(self):
+        """Request both left and right encoder values."""
+        self._serial.write(ENCODERS_BOTH)
+        response = self._serial.read(4)
+        left = int.from_bytes(response[:2], 'little')
+        right = int.from_bytes(response[2:], 'little')
+        return EncoderValues(left, right)

--- a/raspibot/Serial.py
+++ b/raspibot/Serial.py
@@ -17,6 +17,16 @@ ACK = b'\x10'
 NAK = b'\x14'
 
 
+class InvalidResponseException(Exception):
+    """
+    Raised when the protocol implementation reads an unexpected byte.
+
+    This is typically something that is neither an ACK nor a NAK.
+    """
+
+    pass
+
+
 class AttinyProtocol(object):
     """Provides methods for protocol transactions."""
 

--- a/raspibot/Serial.py
+++ b/raspibot/Serial.py
@@ -75,7 +75,7 @@ class AttinyProtocol(object):
         return value
 
     def reset_encoders(self):
-        """Request an 'alive' signal from the microcontroller."""
+        """Reset both left and right encoder counters to zero."""
         self._serial.write(ENCODERS_RESET_BOTH)
         response = self._serial.read(1)
         if response == ACK:
@@ -88,7 +88,7 @@ class AttinyProtocol(object):
             raise InvalidResponseException()
 
     def reset_left_encoder(self):
-        """Request an 'alive' signal from the microcontroller."""
+        """Reset the left encoder counter to zero."""
         self._serial.write(ENCODERS_RESET_LEFT)
         response = self._serial.read(1)
         if response == ACK:
@@ -101,7 +101,7 @@ class AttinyProtocol(object):
             raise InvalidResponseException()
 
     def reset_right_encoder(self):
-        """Request an 'alive' signal from the microcontroller."""
+        """Reset the right encoder counter to zero."""
         self._serial.write(ENCODERS_RESET_RIGHT)
         response = self._serial.read(1)
         if response == ACK:

--- a/raspibot/Serial.py
+++ b/raspibot/Serial.py
@@ -127,3 +127,25 @@ class AttinyProtocol(object):
             return False
         else:
             raise InvalidResponseException()
+
+    def set_right_motor(self, speed):
+        """
+        Set the speed of the right motor.
+
+        Values can be in the range [-127, 127]. Speeds higher than that will be
+        set to their respective extreme. Negative values turn the wheel
+        backwards, positive values turn it forwards. Zero stops the motor.
+        Higher absolute values mean higher speed.
+        """
+        speed = _clamp(speed, MOTOR_MIN, MOTOR_MAX)
+        speed_bytes = speed.to_bytes(1, 'little', signed=True)
+
+        self._serial.write(SET_RIGHT_MOTOR + speed_bytes)
+
+        response = self._serial.read(1)
+        if response == ACK:
+            return True
+        elif response == NAK or response == b'':
+            return False
+        else:
+            raise InvalidResponseException()

--- a/raspibot/Serial.py
+++ b/raspibot/Serial.py
@@ -27,6 +27,7 @@ SET_BOTH_MOTORS = b'\x2D'
 SET_PI_PARAMETERS = b'\x2F'
 
 SET_BUZZER = b'\x40'
+STOP_BUZZER = b'\x43'
 
 # Responses
 ACK = b'\x10'
@@ -288,6 +289,18 @@ class AttinyProtocol(object):
 
         self._serial.write(message)
 
+        response = self._serial.read(1)
+        if response == ACK:
+            return True
+        elif response == NAK or response == b'':
+            return False
+        else:
+            raise InvalidResponseException()
+
+    def stop_buzzer(self):
+        """Stop any buzzer sound."""
+        self._serial.write(STOP_BUZZER)
+        
         response = self._serial.read(1)
         if response == ACK:
             return True

--- a/raspibot/Serial.py
+++ b/raspibot/Serial.py
@@ -51,22 +51,22 @@ class AttinyProtocol(object):
         """Request both left and right encoder values."""
         self._serial.write(ENCODERS_BOTH)
         response = self._serial.read(4)
-        left = int.from_bytes(response[:2], 'little')
-        right = int.from_bytes(response[2:], 'little')
+        left = int.from_bytes(response[:2], 'big')
+        right = int.from_bytes(response[2:], 'big')
         return EncoderValues(left, right)
 
     def get_left_encoder(self):
         """Request the left encoder value."""
         self._serial.write(ENCODERS_LEFT)
         response = self._serial.read(2)
-        value = int.from_bytes(response, 'little')
+        value = int.from_bytes(response, 'big')
         return value
 
     def get_right_encoder(self):
         """Request the right encoder value."""
         self._serial.write(ENCODERS_RIGHT)
         response = self._serial.read(2)
-        value = int.from_bytes(response, 'little')
+        value = int.from_bytes(response, 'big')
         return value
 
     def alive(self):
@@ -93,8 +93,8 @@ class AttinyProtocol(object):
         """
         left = _clamp(left, MOTOR_MIN, MOTOR_MAX)
         right = _clamp(right, MOTOR_MIN, MOTOR_MAX)
-        left_bytes = left.to_bytes(1, 'little', signed=True)
-        right_bytes = right.to_bytes(1, 'little', signed=True)
+        left_bytes = left.to_bytes(1, 'big', signed=True)
+        right_bytes = right.to_bytes(1, 'big', signed=True)
 
         self._serial.write(SET_BOTH_MOTORS + left_bytes + right_bytes)
 
@@ -116,7 +116,7 @@ class AttinyProtocol(object):
         Higher absolute values mean higher speed.
         """
         speed = _clamp(speed, MOTOR_MIN, MOTOR_MAX)
-        speed_bytes = speed.to_bytes(1, 'little', signed=True)
+        speed_bytes = speed.to_bytes(1, 'big', signed=True)
 
         self._serial.write(SET_LEFT_MOTOR + speed_bytes)
 
@@ -138,7 +138,7 @@ class AttinyProtocol(object):
         Higher absolute values mean higher speed.
         """
         speed = _clamp(speed, MOTOR_MIN, MOTOR_MAX)
-        speed_bytes = speed.to_bytes(1, 'little', signed=True)
+        speed_bytes = speed.to_bytes(1, 'big', signed=True)
 
         self._serial.write(SET_RIGHT_MOTOR + speed_bytes)
 

--- a/raspibot/Serial.py
+++ b/raspibot/Serial.py
@@ -61,4 +61,11 @@ class AttinyProtocol(object):
         """Request an 'alive' signal from the microcontroller."""
         self._serial.write(ALIVE)
         response = self._serial.read(1)
-        return response == ACK
+        if response == ACK:
+            return True
+        # empty response can happen on a timeout, which we interpret as
+        # "not alive"
+        elif response == NAK or response == b'':
+            return False
+        else:
+            raise InvalidResponseException()

--- a/raspibot/Serial.py
+++ b/raspibot/Serial.py
@@ -8,9 +8,14 @@ EncoderValues = namedtuple('EncoderValues', 'left right')
 
 # Requests
 ALIVE = b'\x01'
+
 ENCODERS_RIGHT = b'\x02'
 ENCODERS_LEFT = b'\x03'
 ENCODERS_BOTH = b'\x04'
+
+ENCODERS_RESET_RIGHT = b'\x05'
+ENCODERS_RESET_LEFT = b'\x06'
+ENCODERS_RESET_BOTH = b'\x07'
 
 SET_LEFT_MOTOR = b'\x29'
 SET_RIGHT_MOTOR = b'\x25'
@@ -68,6 +73,45 @@ class AttinyProtocol(object):
         response = self._serial.read(2)
         value = int.from_bytes(response, 'big')
         return value
+
+    def reset_encoders(self):
+        """Request an 'alive' signal from the microcontroller."""
+        self._serial.write(ENCODERS_RESET_BOTH)
+        response = self._serial.read(1)
+        if response == ACK:
+            return True
+        # empty response can happen on a timeout, which we interpret as
+        # "not alive"
+        elif response == NAK or response == b'':
+            return False
+        else:
+            raise InvalidResponseException()
+
+    def reset_left_encoder(self):
+        """Request an 'alive' signal from the microcontroller."""
+        self._serial.write(ENCODERS_RESET_LEFT)
+        response = self._serial.read(1)
+        if response == ACK:
+            return True
+        # empty response can happen on a timeout, which we interpret as
+        # "not alive"
+        elif response == NAK or response == b'':
+            return False
+        else:
+            raise InvalidResponseException()
+
+    def reset_right_encoder(self):
+        """Request an 'alive' signal from the microcontroller."""
+        self._serial.write(ENCODERS_RESET_RIGHT)
+        response = self._serial.read(1)
+        if response == ACK:
+            return True
+        # empty response can happen on a timeout, which we interpret as
+        # "not alive"
+        elif response == NAK or response == b'':
+            return False
+        else:
+            raise InvalidResponseException()
 
     def alive(self):
         """Request an 'alive' signal from the microcontroller."""

--- a/raspibot/Serial.py
+++ b/raspibot/Serial.py
@@ -6,6 +6,8 @@ EncoderValues = namedtuple('EncoderValues', 'left right')
 
 # Named byte values for the protocol commands
 ENCODERS_BOTH = b'\x04'
+ENCODERS_LEFT = b'\x03'
+ENCODERS_RIGHT = b'\x02'
 
 
 class AttinyProtocol(object):
@@ -23,3 +25,17 @@ class AttinyProtocol(object):
         left = int.from_bytes(response[:2], 'little')
         right = int.from_bytes(response[2:], 'little')
         return EncoderValues(left, right)
+
+    def get_left_encoder(self):
+        """Request the left encoder value."""
+        self._serial.write(ENCODERS_LEFT)
+        response = self._serial.read(2)
+        value = int.from_bytes(response, 'little')
+        return value
+
+    def get_right_encoder(self):
+        """Request the right encoder value."""
+        self._serial.write(ENCODERS_RIGHT)
+        response = self._serial.read(2)
+        value = int.from_bytes(response, 'little')
+        return value

--- a/raspibot/Serial.py
+++ b/raspibot/Serial.py
@@ -105,3 +105,25 @@ class AttinyProtocol(object):
             return False
         else:
             raise InvalidResponseException()
+
+    def set_left_motor(self, speed):
+        """
+        Set the speed of the left motor.
+
+        Values can be in the range [-127, 127]. Speeds higher than that will be
+        set to their respective extreme. Negative values turn the wheel
+        backwards, positive values turn it forwards. Zero stops the motor.
+        Higher absolute values mean higher speed.
+        """
+        speed = _clamp(speed, MOTOR_MIN, MOTOR_MAX)
+        speed_bytes = speed.to_bytes(1, 'little', signed=True)
+
+        self._serial.write(SET_LEFT_MOTOR + speed_bytes)
+
+        response = self._serial.read(1)
+        if response == ACK:
+            return True
+        elif response == NAK or response == b'':
+            return False
+        else:
+            raise InvalidResponseException()

--- a/raspibot/Serial.py
+++ b/raspibot/Serial.py
@@ -5,9 +5,16 @@ from collections import namedtuple
 EncoderValues = namedtuple('EncoderValues', 'left right')
 
 # Named byte values for the protocol commands
-ENCODERS_BOTH = b'\x04'
-ENCODERS_LEFT = b'\x03'
+
+# Requests
+ALIVE = b'\x01'
 ENCODERS_RIGHT = b'\x02'
+ENCODERS_LEFT = b'\x03'
+ENCODERS_BOTH = b'\x04'
+
+# Responses
+ACK = b'\x10'
+NAK = b'\x14'
 
 
 class AttinyProtocol(object):
@@ -39,3 +46,9 @@ class AttinyProtocol(object):
         response = self._serial.read(2)
         value = int.from_bytes(response, 'little')
         return value
+
+    def alive(self):
+        """Request an 'alive' signal from the microcontroller."""
+        self._serial.write(ALIVE)
+        response = self._serial.read(1)
+        return response == ACK

--- a/raspibot/Serial.py
+++ b/raspibot/Serial.py
@@ -17,6 +17,8 @@ ENCODERS_RESET_RIGHT = b'\x05'
 ENCODERS_RESET_LEFT = b'\x06'
 ENCODERS_RESET_BOTH = b'\x07'
 
+ECHO = b'\x0C'
+
 STOP_MOTORS = b'\x21'
 SET_LEFT_MOTOR = b'\x29'
 SET_RIGHT_MOTOR = b'\x25'
@@ -40,6 +42,12 @@ class InvalidResponseException(Exception):
 
     This is typically something that is neither an ACK nor a NAK.
     """
+
+    pass
+
+
+class InvalidLengthException(Exception):
+    """Raised when the "Echo" command receives none or more than one byte."""
 
     pass
 
@@ -125,6 +133,16 @@ class AttinyProtocol(object):
             return False
         else:
             raise InvalidResponseException()
+
+    def echo(self, byte):
+        """Receive back the same byte that was sent to the ATtiny."""
+        if len(byte) != 1:
+            raise InvalidLengthException()
+        self._serial.write(ECHO + byte)
+        response = self._serial.read(1)
+        if response != byte:
+            raise InvalidResponseException()
+        return response
 
     def stop_motors(self):
         """Immediately stops both motors."""

--- a/tests/test_Serial.py
+++ b/tests/test_Serial.py
@@ -159,11 +159,13 @@ def test_set_both_motors_zero():
     right_bytes = BYTES_MOTOR_ZERO
     
     attiny = AttinyProtocol(serial)
-    attiny.set_motors(left, right)
+    result = attiny.set_motors(left, right)
     
     assert len(serial.received) == 3
     assert serial.received[0] == SET_BOTH_MOTORS
     assert serial.received[1] == left_bytes
     assert serial.received[2] == right_bytes
+    
+    assert result == True
     
 # flake8: noqa

--- a/tests/test_Serial.py
+++ b/tests/test_Serial.py
@@ -12,14 +12,19 @@ ENCODERS_RESET_RIGHT = b'\x05'
 ENCODERS_RESET_LEFT = b'\x06'
 ENCODERS_RESET_BOTH = b'\x07'
 
+ECHO = b'\x0C'
+
 ACK = b'\x10'
 NAK = b'\x14'
+
+INVALID_RESPONSE = b'\x23'
 
 STOP_MOTORS = b'\x21'
 
 SET_RIGHT_MOTOR = b'\x25'
 SET_LEFT_MOTOR = b'\x29'
 SET_BOTH_MOTORS = b'\x2D'
+
 
 MOTOR_MIN = -127
 MOTOR_MAX = 127
@@ -29,8 +34,6 @@ MOTOR_ZERO = 0
 BYTES_MOTOR_MIN = MOTOR_MIN.to_bytes(1, 'big', signed=True)
 BYTES_MOTOR_MAX = MOTOR_MAX.to_bytes(1, 'big', signed=True)
 BYTES_MOTOR_ZERO = MOTOR_ZERO.to_bytes(1, 'big', signed=True)
-
-INVALID_RESPONSE = b'\x23'
 
 class MockSerial:
 
@@ -230,6 +233,30 @@ def test_alive_undefined():
         attiny.alive()
 
     assert serial.received == ALIVE
+    
+ECHO_TEST = b'\x88'
+# a byte that is not ECHO_TEST
+ECHO_INVALID = b'\x44'
+
+def test_echo():
+    serial = MockSerial(ECHO_TEST)
+    
+    attiny = AttinyProtocol(serial)
+    
+    response = attiny.echo(ECHO_TEST)
+    
+    assert serial.received == ECHO + ECHO_TEST
+    assert response == ECHO_TEST
+
+def test_echo_invalid():
+    serial = MockSerial(ECHO_INVALID)
+    
+    attiny = AttinyProtocol(serial)
+    
+    with pytest.raises(InvalidResponseException):
+        attiny.echo(ECHO_TEST)
+    
+    assert serial.received == ECHO + ECHO_TEST
     
 def test_stop_motors():
     serial = MockSerial(ACK)

--- a/tests/test_Serial.py
+++ b/tests/test_Serial.py
@@ -131,10 +131,38 @@ def test_set_right_motor_min():
     
     assert result == True
 
+def test_set_right_motor_under_min():
+    serial = MockSerial(ACK)
+    
+    right = MOTOR_MIN - 1
+    right_bytes = BYTES_MOTOR_MIN
+    
+    attiny = AttinyProtocol(serial)
+    result = attiny.set_right_motor(right)
+    
+    assert len(serial.received) == 2
+    assert serial.received == SET_RIGHT_MOTOR + right_bytes
+    
+    assert result == True
+
 def test_set_right_motor_max():
     serial = MockSerial(ACK)
     
     right = MOTOR_MAX
+    right_bytes = BYTES_MOTOR_MAX
+    
+    attiny = AttinyProtocol(serial)
+    result = attiny.set_right_motor(right)
+    
+    assert len(serial.received) == 2
+    assert serial.received == SET_RIGHT_MOTOR + right_bytes
+    
+    assert result == True
+
+def test_set_right_motor_over_max():
+    serial = MockSerial(ACK)
+    
+    right = MOTOR_MAX + 1
     right_bytes = BYTES_MOTOR_MAX
     
     attiny = AttinyProtocol(serial)
@@ -197,11 +225,38 @@ def test_set_left_motor_min():
     
     assert result == True
 
+def test_set_left_motor_under_min():
+    serial = MockSerial(ACK)
+    
+    left = MOTOR_MIN - 1
+    left_bytes = BYTES_MOTOR_MIN
+    
+    attiny = AttinyProtocol(serial)
+    result = attiny.set_left_motor(left);
+    
+    assert len(serial.received) == 2
+    assert serial.received == SET_LEFT_MOTOR + left_bytes
+    
+    assert result == True
 
 def test_set_left_motor_max():
     serial = MockSerial(ACK)
     
     left = MOTOR_MAX
+    left_bytes = BYTES_MOTOR_MAX
+    
+    attiny = AttinyProtocol(serial)
+    result = attiny.set_left_motor(left);
+    
+    assert len(serial.received) == 2
+    assert serial.received == SET_LEFT_MOTOR + left_bytes
+    
+    assert result == True
+
+def test_set_left_motor_over_max():
+    serial = MockSerial(ACK)
+    
+    left = MOTOR_MAX + 1
     left_bytes = BYTES_MOTOR_MAX
     
     attiny = AttinyProtocol(serial)
@@ -253,8 +308,7 @@ def test_set_left_motor_invalid():
     with pytest.raises(InvalidResponseException):
         attiny.set_left_motor(0)
 
-    
-def test_set_both_motors():
+def test_set_both_motors_minmax():
     serial = MockSerial(ACK)
     
     left = MOTOR_MIN
@@ -269,13 +323,43 @@ def test_set_both_motors():
     assert len(serial.received) == 3
     assert serial.received == SET_BOTH_MOTORS + left_bytes + right_bytes
     
-def test_set_both_motors2():
+def test_set_both_motors_exceed_minmax():
+    serial = MockSerial(ACK)
+    
+    left = MOTOR_MIN - 1
+    left_bytes = BYTES_MOTOR_MIN
+    
+    right = MOTOR_MAX + 1
+    right_bytes = BYTES_MOTOR_MAX
+    
+    attiny = AttinyProtocol(serial)
+    attiny.set_motors(left, right)
+    
+    assert len(serial.received) == 3
+    assert serial.received == SET_BOTH_MOTORS + left_bytes + right_bytes
+    
+def test_set_both_motors_maxmin():
     serial = MockSerial(ACK)
     
     left = MOTOR_MAX
     left_bytes = BYTES_MOTOR_MAX
     
     right = MOTOR_MIN
+    right_bytes = BYTES_MOTOR_MIN
+    
+    attiny = AttinyProtocol(serial)
+    attiny.set_motors(left, right)
+    
+    assert len(serial.received) == 3
+    assert serial.received == SET_BOTH_MOTORS + left_bytes + right_bytes
+    
+def test_set_both_motors_exceed_maxmin():
+    serial = MockSerial(ACK)
+    
+    left = MOTOR_MAX + 1
+    left_bytes = BYTES_MOTOR_MAX
+    
+    right = MOTOR_MIN - 1
     right_bytes = BYTES_MOTOR_MIN
     
     attiny = AttinyProtocol(serial)

--- a/tests/test_Serial.py
+++ b/tests/test_Serial.py
@@ -128,9 +128,7 @@ def test_set_both_motors():
     attiny.set_motors(left, right)
     
     assert len(serial.received) == 3
-    assert serial.received[0] == SET_BOTH_MOTORS
-    assert serial.received[1] == left_bytes
-    assert serial.received[2] == right_bytes
+    assert serial.received == SET_BOTH_MOTORS + left_bytes + right_bytes
     
 def test_set_both_motors2():
     serial = MockSerial(ACK)
@@ -145,9 +143,7 @@ def test_set_both_motors2():
     attiny.set_motors(left, right)
     
     assert len(serial.received) == 3
-    assert serial.received[0] == SET_BOTH_MOTORS
-    assert serial.received[1] == left_bytes
-    assert serial.received[2] == right_bytes
+    assert serial.received == SET_BOTH_MOTORS + left_bytes + right_bytes
     
 def test_set_both_motors_zero():
     serial = MockSerial(ACK)
@@ -162,9 +158,7 @@ def test_set_both_motors_zero():
     result = attiny.set_motors(left, right)
     
     assert len(serial.received) == 3
-    assert serial.received[0] == SET_BOTH_MOTORS
-    assert serial.received[1] == left_bytes
-    assert serial.received[2] == right_bytes
+    assert serial.received == SET_BOTH_MOTORS + left_bytes + right_bytes
     
     assert result == True
     

--- a/tests/test_Serial.py
+++ b/tests/test_Serial.py
@@ -11,6 +11,7 @@ ENCODERS_BOTH = b'\x04'
 ACK = b'\x10'
 NAK = b'\x14'
 
+SET_LEFT_MOTOR = b'\x29'
 SET_BOTH_MOTORS = b'\x2D'
 
 MOTOR_MIN = -127
@@ -114,6 +115,78 @@ def test_alive_undefined():
         attiny.alive()
 
     assert serial.received == ALIVE
+
+
+def test_set_left_motor_min():
+    serial = MockSerial(ACK)
+    
+    left = MOTOR_MIN
+    left_bytes = BYTES_MOTOR_MIN
+    
+    attiny = AttinyProtocol(serial)
+    result = attiny.set_left_motor(left);
+    
+    assert len(serial.received) == 2
+    assert serial.received == SET_LEFT_MOTOR + left_bytes
+    
+    assert result == True
+
+
+def test_set_left_motor_max():
+    serial = MockSerial(ACK)
+    
+    left = MOTOR_MAX
+    left_bytes = BYTES_MOTOR_MAX
+    
+    attiny = AttinyProtocol(serial)
+    result = attiny.set_left_motor(left);
+    
+    assert len(serial.received) == 2
+    assert serial.received == SET_LEFT_MOTOR + left_bytes
+    
+    assert result == True
+
+
+def test_set_left_motor_zero():
+    serial = MockSerial(ACK)
+    
+    left = MOTOR_ZERO
+    left_bytes = BYTES_MOTOR_ZERO
+    
+    attiny = AttinyProtocol(serial)
+    result = attiny.set_left_motor(left);
+    
+    assert len(serial.received) == 2
+    assert serial.received == SET_LEFT_MOTOR + left_bytes
+    
+    assert result == True
+
+
+def test_set_left_motor_nak():
+    serial = MockSerial(NAK)
+    
+    attiny = AttinyProtocol(serial)
+    result = attiny.set_left_motor(0)
+    
+    assert result == False
+
+
+def test_set_left_motor_timeout():
+    serial = MockSerial(b'')
+    
+    attiny = AttinyProtocol(serial)
+    result = attiny.set_left_motor(0)
+    
+    assert result == False
+
+
+def test_set_left_motor_invalid():
+    serial = MockSerial(INVALID_RESPONSE)
+    
+    attiny = AttinyProtocol(serial)
+    with pytest.raises(InvalidResponseException):
+        attiny.set_left_motor(0)
+
     
 def test_set_both_motors():
     serial = MockSerial(ACK)
@@ -184,6 +257,4 @@ def test_set_both_motors_invalid():
     attiny = AttinyProtocol(serial)
     with pytest.raises(InvalidResponseException):
         attiny.set_motors(0, 0)
-
-
 # flake8: noqa

--- a/tests/test_Serial.py
+++ b/tests/test_Serial.py
@@ -176,7 +176,7 @@ def test_set_right_motor_timeout():
     assert result == False
 
 def test_set_right_motor_invalid():
-    serial = MockSerial(b'')
+    serial = MockSerial(INVALID_RESPONSE)
     
     attiny = AttinyProtocol(serial)
     with pytest.raises(InvalidResponseException):

--- a/tests/test_Serial.py
+++ b/tests/test_Serial.py
@@ -1,4 +1,4 @@
-from raspibot.Serial import AttinyProtocol, InvalidResponseException
+from raspibot.Serial import AttinyProtocol, InvalidResponseException, InvalidLengthException
 
 import pytest
 
@@ -247,6 +247,16 @@ def test_echo():
     
     assert serial.received == ECHO + ECHO_TEST
     assert response == ECHO_TEST
+
+def test_echo_too_long():
+    serial = MockSerial(b'')
+    
+    attiny = AttinyProtocol(serial)
+    
+    with pytest.raises(InvalidLengthException):
+        attiny.echo(b'abcd')
+        
+    assert serial.received == b''
 
 def test_echo_invalid():
     serial = MockSerial(ECHO_INVALID)

--- a/tests/test_Serial.py
+++ b/tests/test_Serial.py
@@ -1,0 +1,40 @@
+from raspibot.Serial import AttinyProtocol
+
+
+class MockSerial:
+
+    def __init__(self, bytes):
+        self._bytes = bytes
+        self._position = 0
+
+    def write(self, bytes):
+        pass
+
+    def read(self, count):
+        try:
+            return self._bytes[self._position:self._position+count]
+            self._position += count
+        except IndexError:
+            return b''
+
+
+def test_get_encoders():
+    left, right = 0, 65535
+    encoder_bytes = left.to_bytes(2, 'little') + right.to_bytes(2, 'little')
+    serial = MockSerial(encoder_bytes)
+    
+    attiny = AttinyProtocol(serial)
+    result = attiny.get_encoders()
+    
+    # use it as a tuple
+    assert result == (left, right)
+    
+    # access tuple fields by index
+    assert result[0] == left
+    assert result[1] == right
+    
+    # access tuple fields by name
+    assert result.left == left
+    assert result.right == right
+    
+# flake8: noqa

--- a/tests/test_Serial.py
+++ b/tests/test_Serial.py
@@ -28,6 +28,7 @@ SET_BOTH_MOTORS = b'\x2D'
 SET_PI = b'\x2F'
 
 SET_BUZZER = b'\x40'
+STOP_BUZZER = b'\x43'
 
 MOTOR_MIN = -127
 MOTOR_MAX = 127
@@ -839,5 +840,34 @@ def test_set_buzzer_invalid():
     
     with pytest.raises(InvalidResponseException):
         attiny.set_buzzer(0, 0, 0)
+        
+def test_stop_buzzer():
+    serial = MockSerial(ACK)
+    attiny = AttinyProtocol(serial)
+    result = attiny.stop_buzzer()
+    
+    assert result == True
+    assert serial.received == STOP_BUZZER
+    
+def test_stop_buzzer_nak():
+    serial = MockSerial(NAK)
+    attiny = AttinyProtocol(serial)
+    result = attiny.stop_buzzer()
+    
+    assert result == False
+    
+def test_stop_buzzer_timeout():
+    serial = MockSerial(b'')
+    attiny = AttinyProtocol(serial)
+    result = attiny.stop_buzzer()
+    
+    assert result == False
+    
+def test_stop_buzzer_invalid():
+    serial = MockSerial(INVALID_RESPONSE)
+    attiny = AttinyProtocol(serial)
+    
+    with pytest.raises(InvalidResponseException):
+        attiny.stop_buzzer()
     
 # flake8: noqa

--- a/tests/test_Serial.py
+++ b/tests/test_Serial.py
@@ -37,4 +37,24 @@ def test_get_encoders():
     assert result.left == left
     assert result.right == right
     
+def test_get_left_encoder():
+    value = 43690
+    encoder_bytes = value.to_bytes(2, 'little')
+    serial = MockSerial(encoder_bytes)
+    
+    attiny = AttinyProtocol(serial)
+    result = attiny.get_left_encoder()
+    
+    assert result == value
+    
+def test_get_right_encoder():
+    value = 21845
+    encoder_bytes = value.to_bytes(2, 'little')
+    serial = MockSerial(encoder_bytes)
+    
+    attiny = AttinyProtocol(serial)
+    result = attiny.get_right_encoder()
+    
+    assert result == value
+    
 # flake8: noqa

--- a/tests/test_Serial.py
+++ b/tests/test_Serial.py
@@ -6,9 +6,10 @@ class MockSerial:
     def __init__(self, bytes):
         self._bytes = bytes
         self._position = 0
+        self.received = b''
 
     def write(self, bytes):
-        pass
+        self.received += bytes
 
     def read(self, count):
         try:
@@ -25,6 +26,8 @@ def test_get_encoders():
     
     attiny = AttinyProtocol(serial)
     result = attiny.get_encoders()
+    
+    assert serial.received == b'\x04'
     
     # use it as a tuple
     assert result == (left, right)
@@ -45,6 +48,7 @@ def test_get_left_encoder():
     attiny = AttinyProtocol(serial)
     result = attiny.get_left_encoder()
     
+    assert serial.received == b'\x03'
     assert result == value
     
 def test_get_right_encoder():
@@ -55,6 +59,7 @@ def test_get_right_encoder():
     attiny = AttinyProtocol(serial)
     result = attiny.get_right_encoder()
     
+    assert serial.received == b'\x02'
     assert result == value
     
 # flake8: noqa

--- a/tests/test_Serial.py
+++ b/tests/test_Serial.py
@@ -91,6 +91,40 @@ def test_get_right_encoder():
     assert serial.received == ENCODERS_RIGHT
     assert result == value
     
+def test_reset_left_encoder():
+    serial = MockSerial(ACK)
+    attiny = AttinyProtocol(serial)
+    
+    result = attiny.reset_left_encoder()
+    
+    assert serial.received == ENCODERS_RESET_LEFT
+    assert result == True
+    
+def test_reset_left_encoder_nak():
+    serial = MockSerial(NAK)
+    attiny = AttinyProtocol(serial)
+    
+    result = attiny.reset_left_encoder()
+    
+    assert serial.received == ENCODERS_RESET_LEFT
+    assert result == False
+    
+def test_reset_left_encoder_timeout():
+    serial = MockSerial(b'')
+    attiny = AttinyProtocol(serial)
+    
+    result = attiny.reset_left_encoder()
+    
+    assert serial.received == ENCODERS_RESET_LEFT
+    assert result == False
+    
+def test_reset_left_encoder_invalid():
+    serial = MockSerial(INVALID_RESPONSE)
+    attiny = AttinyProtocol(serial)
+    
+    with pytest.raises(InvalidResponseException):
+        attiny.reset_left_encoder()
+    
 def test_alive_ack():
     # send out an ACK byte
     serial = MockSerial(ACK)

--- a/tests/test_Serial.py
+++ b/tests/test_Serial.py
@@ -163,6 +163,42 @@ def test_reset_left_encoder_invalid():
         
     assert serial.received == ENCODERS_RESET_LEFT
     
+def test_reset_both_encoders():
+    serial = MockSerial(ACK)
+    attiny = AttinyProtocol(serial)
+    
+    result = attiny.reset_encoders()
+    
+    assert serial.received == ENCODERS_RESET_BOTH
+    assert result == True
+    
+def test_reset_both_encoders_nak():
+    serial = MockSerial(NAK)
+    attiny = AttinyProtocol(serial)
+    
+    result = attiny.reset_encoders()
+    
+    assert serial.received == ENCODERS_RESET_BOTH
+    assert result == False
+    
+def test_reset_both_encoders_timeout():
+    serial = MockSerial(b'')
+    attiny = AttinyProtocol(serial)
+    
+    result = attiny.reset_encoders()
+    
+    assert serial.received == ENCODERS_RESET_BOTH
+    assert result == False
+    
+def test_reset_both_encoders_invalid():
+    serial = MockSerial(INVALID_RESPONSE)
+    attiny = AttinyProtocol(serial)
+    
+    with pytest.raises(InvalidResponseException):
+        attiny.reset_encoders()
+        
+    assert serial.received == ENCODERS_RESET_BOTH
+    
 def test_alive_ack():
     # send out an ACK byte
     serial = MockSerial(ACK)

--- a/tests/test_Serial.py
+++ b/tests/test_Serial.py
@@ -15,6 +15,8 @@ ENCODERS_RESET_BOTH = b'\x07'
 ACK = b'\x10'
 NAK = b'\x14'
 
+STOP_MOTORS = b'\x21'
+
 SET_RIGHT_MOTOR = b'\x25'
 SET_LEFT_MOTOR = b'\x29'
 SET_BOTH_MOTORS = b'\x2D'
@@ -228,6 +230,46 @@ def test_alive_undefined():
         attiny.alive()
 
     assert serial.received == ALIVE
+    
+def test_stop_motors():
+    serial = MockSerial(ACK)
+    
+    attiny = AttinyProtocol(serial)
+    result = attiny.stop_motors()
+    
+    assert serial.received == STOP_MOTORS
+    
+    assert result == True
+    
+def test_stop_motors_nak():
+    serial = MockSerial(NAK)
+    
+    attiny = AttinyProtocol(serial)
+    result = attiny.stop_motors()
+    
+    assert serial.received == STOP_MOTORS
+    
+    assert result == False
+    
+def test_stop_motors_timeout():
+    serial = MockSerial(b'')
+    
+    attiny = AttinyProtocol(serial)
+    result = attiny.stop_motors()
+    
+    assert serial.received == STOP_MOTORS
+    
+    assert result == False
+    
+def test_stop_motors_undefined():
+    # send out something that is neither an ACK or a NAK byte
+    serial = MockSerial(INVALID_RESPONSE)
+    
+    attiny = AttinyProtocol(serial)
+    with pytest.raises(InvalidResponseException):
+        attiny.stop_motors()
+
+    assert serial.received == STOP_MOTORS
 
 def test_set_right_motor_min():
     serial = MockSerial(ACK)

--- a/tests/test_Serial.py
+++ b/tests/test_Serial.py
@@ -91,6 +91,40 @@ def test_get_right_encoder():
     assert serial.received == ENCODERS_RIGHT
     assert result == value
     
+def test_reset_right_encoder():
+    serial = MockSerial(ACK)
+    attiny = AttinyProtocol(serial)
+    
+    result = attiny.reset_right_encoder()
+    
+    assert serial.received == ENCODERS_RESET_RIGHT
+    assert result == True
+    
+def test_reset_right_encoder_nak():
+    serial = MockSerial(NAK)
+    attiny = AttinyProtocol(serial)
+    
+    result = attiny.reset_right_encoder()
+    
+    assert serial.received == ENCODERS_RESET_RIGHT
+    assert result == False
+    
+def test_reset_right_encoder_timeout():
+    serial = MockSerial(b'')
+    attiny = AttinyProtocol(serial)
+    
+    result = attiny.reset_right_encoder()
+    
+    assert serial.received == ENCODERS_RESET_RIGHT
+    assert result == False
+    
+def test_reset_right_encoder_invalid():
+    serial = MockSerial(INVALID_RESPONSE)
+    attiny = AttinyProtocol(serial)
+    
+    with pytest.raises(InvalidResponseException):
+        attiny.reset_right_encoder()
+    
 def test_reset_left_encoder():
     serial = MockSerial(ACK)
     attiny = AttinyProtocol(serial)

--- a/tests/test_Serial.py
+++ b/tests/test_Serial.py
@@ -11,6 +11,17 @@ ENCODERS_BOTH = b'\x04'
 ACK = b'\x10'
 NAK = b'\x14'
 
+SET_BOTH_MOTORS = b'\x2D'
+
+MOTOR_MIN = -127
+MOTOR_MAX = 127
+MOTOR_ZERO = 0
+
+# as signed byte values:
+BYTES_MOTOR_MIN = MOTOR_MIN.to_bytes(1, 'little', signed=True)
+BYTES_MOTOR_MAX = MOTOR_MAX.to_bytes(1, 'little', signed=True)
+BYTES_MOTOR_ZERO = MOTOR_ZERO.to_bytes(1, 'little', signed=True)
+
 INVALID_RESPONSE = b'\x23'
 
 class MockSerial:
@@ -103,5 +114,56 @@ def test_alive_undefined():
         attiny.alive()
 
     assert serial.received == ALIVE
+    
+def test_set_both_motors():
+    serial = MockSerial(ACK)
+    
+    left = MOTOR_MIN
+    left_bytes = BYTES_MOTOR_MIN
+    
+    right = MOTOR_MAX
+    right_bytes = BYTES_MOTOR_MAX
+    
+    attiny = AttinyProtocol(serial)
+    attiny.set_motors(left, right)
+    
+    assert len(serial.received) == 3
+    assert serial.received[0] == SET_BOTH_MOTORS
+    assert serial.received[1] == left_bytes
+    assert serial.received[2] == right_bytes
+    
+def test_set_both_motors2():
+    serial = MockSerial(ACK)
+    
+    left = MOTOR_MAX
+    left_bytes = BYTES_MOTOR_MAX
+    
+    right = MOTOR_MIN
+    right_bytes = BYTES_MOTOR_MIN
+    
+    attiny = AttinyProtocol(serial)
+    attiny.set_motors(left, right)
+    
+    assert len(serial.received) == 3
+    assert serial.received[0] == SET_BOTH_MOTORS
+    assert serial.received[1] == left_bytes
+    assert serial.received[2] == right_bytes
+    
+def test_set_both_motors_zero():
+    serial = MockSerial(ACK)
+    
+    left = MOTOR_ZERO
+    left_bytes = BYTES_MOTOR_ZERO
+    
+    right = MOTOR_ZERO
+    right_bytes = BYTES_MOTOR_ZERO
+    
+    attiny = AttinyProtocol(serial)
+    attiny.set_motors(left, right)
+    
+    assert len(serial.received) == 3
+    assert serial.received[0] == SET_BOTH_MOTORS
+    assert serial.received[1] == left_bytes
+    assert serial.received[2] == right_bytes
     
 # flake8: noqa

--- a/tests/test_Serial.py
+++ b/tests/test_Serial.py
@@ -124,6 +124,8 @@ def test_reset_right_encoder_invalid():
     
     with pytest.raises(InvalidResponseException):
         attiny.reset_right_encoder()
+        
+    assert serial.received == ENCODERS_RESET_RIGHT
     
 def test_reset_left_encoder():
     serial = MockSerial(ACK)
@@ -158,6 +160,8 @@ def test_reset_left_encoder_invalid():
     
     with pytest.raises(InvalidResponseException):
         attiny.reset_left_encoder()
+        
+    assert serial.received == ENCODERS_RESET_LEFT
     
 def test_alive_ack():
     # send out an ACK byte
@@ -281,6 +285,8 @@ def test_set_right_motor_invalid():
     attiny = AttinyProtocol(serial)
     with pytest.raises(InvalidResponseException):
         attiny.set_right_motor(0)
+        
+    assert serial.received[:1] == SET_RIGHT_MOTOR
     
 
 def test_set_left_motor_min():
@@ -379,6 +385,8 @@ def test_set_left_motor_invalid():
     attiny = AttinyProtocol(serial)
     with pytest.raises(InvalidResponseException):
         attiny.set_left_motor(0)
+        
+    assert serial.received[:1] == SET_LEFT_MOTOR
 
 def test_set_both_motors_minmax():
     serial = MockSerial(ACK)
@@ -479,5 +487,7 @@ def test_set_both_motors_invalid():
     attiny = AttinyProtocol(serial)
     with pytest.raises(InvalidResponseException):
         attiny.set_motors(0, 0)
+        
+    assert serial.received[:1] == SET_BOTH_MOTORS
 
 # flake8: noqa

--- a/tests/test_Serial.py
+++ b/tests/test_Serial.py
@@ -11,6 +11,7 @@ ENCODERS_BOTH = b'\x04'
 ACK = b'\x10'
 NAK = b'\x14'
 
+SET_RIGHT_MOTOR = b'\x25'
 SET_LEFT_MOTOR = b'\x29'
 SET_BOTH_MOTORS = b'\x2D'
 
@@ -116,6 +117,71 @@ def test_alive_undefined():
 
     assert serial.received == ALIVE
 
+def test_set_right_motor_min():
+    serial = MockSerial(ACK)
+    
+    right = MOTOR_MIN
+    right_bytes = BYTES_MOTOR_MIN
+    
+    attiny = AttinyProtocol(serial)
+    result = attiny.set_right_motor(right)
+    
+    assert len(serial.received) == 2
+    assert serial.received == SET_RIGHT_MOTOR + right_bytes
+    
+    assert result == True
+
+def test_set_right_motor_max():
+    serial = MockSerial(ACK)
+    
+    right = MOTOR_MAX
+    right_bytes = BYTES_MOTOR_MAX
+    
+    attiny = AttinyProtocol(serial)
+    result = attiny.set_right_motor(right)
+    
+    assert len(serial.received) == 2
+    assert serial.received == SET_RIGHT_MOTOR + right_bytes
+    
+    assert result == True
+
+def test_set_right_motor_zero():
+    serial = MockSerial(ACK)
+    
+    right = MOTOR_ZERO
+    right_bytes = BYTES_MOTOR_ZERO
+    
+    attiny = AttinyProtocol(serial)
+    result = attiny.set_right_motor(right)
+    
+    assert len(serial.received) == 2
+    assert serial.received == SET_RIGHT_MOTOR + right_bytes
+    
+    assert result == True
+
+def test_set_right_motor_nak():
+    serial = MockSerial(NAK)
+    
+    attiny = AttinyProtocol(serial)
+    result = attiny.set_right_motor(0)
+    
+    assert result == False
+
+def test_set_right_motor_timeout():
+    serial = MockSerial(b'')
+    
+    attiny = AttinyProtocol(serial)
+    result = attiny.set_right_motor(0)
+    
+    assert result == False
+
+def test_set_right_motor_invalid():
+    serial = MockSerial(b'')
+    
+    attiny = AttinyProtocol(serial)
+    with pytest.raises(InvalidResponseException):
+        attiny.set_right_motor(0)
+    
 
 def test_set_left_motor_min():
     serial = MockSerial(ACK)

--- a/tests/test_Serial.py
+++ b/tests/test_Serial.py
@@ -62,4 +62,14 @@ def test_get_right_encoder():
     assert serial.received == b'\x02'
     assert result == value
     
+def test_alive():
+    # send out an ACK byte
+    serial = MockSerial(b'\x10')
+    
+    attiny = AttinyProtocol(serial)
+    result = attiny.alive()
+    
+    assert serial.received == b'\x01'
+    assert result == True
+    
 # flake8: noqa

--- a/tests/test_Serial.py
+++ b/tests/test_Serial.py
@@ -2,6 +2,16 @@ from raspibot.Serial import AttinyProtocol, InvalidResponseException
 
 import pytest
 
+ALIVE = b'\x01'
+
+ENCODERS_RIGHT = b'\x02'
+ENCODERS_LEFT = b'\x03'
+ENCODERS_BOTH = b'\x04'
+
+ACK = b'\x10'
+NAK = b'\x14'
+
+INVALID_RESPONSE = b'\x23'
 
 class MockSerial:
 
@@ -29,7 +39,7 @@ def test_get_encoders():
     attiny = AttinyProtocol(serial)
     result = attiny.get_encoders()
     
-    assert serial.received == b'\x04'
+    assert serial.received == ENCODERS_BOTH
     
     # use it as a tuple
     assert result == (left, right)
@@ -50,7 +60,7 @@ def test_get_left_encoder():
     attiny = AttinyProtocol(serial)
     result = attiny.get_left_encoder()
     
-    assert serial.received == b'\x03'
+    assert serial.received == ENCODERS_LEFT
     assert result == value
     
 def test_get_right_encoder():
@@ -61,37 +71,37 @@ def test_get_right_encoder():
     attiny = AttinyProtocol(serial)
     result = attiny.get_right_encoder()
     
-    assert serial.received == b'\x02'
+    assert serial.received == ENCODERS_RIGHT
     assert result == value
     
 def test_alive_ack():
     # send out an ACK byte
-    serial = MockSerial(b'\x10')
+    serial = MockSerial(ACK)
     
     attiny = AttinyProtocol(serial)
     result = attiny.alive()
     
-    assert serial.received == b'\x01'
+    assert serial.received == ALIVE
     assert result == True
     
 def test_alive_nak():
     # send out an NAK byte
-    serial = MockSerial(b'\x14')
+    serial = MockSerial(NAK)
     
     attiny = AttinyProtocol(serial)
     result = attiny.alive()
     
-    assert serial.received == b'\x01'
+    assert serial.received == ALIVE
     assert result == False
     
 def test_alive_undefined():
     # send out something that is neither an ACK or a NAK byte
-    serial = MockSerial(b'\x23')
+    serial = MockSerial(INVALID_RESPONSE)
     
     attiny = AttinyProtocol(serial)
     with pytest.raises(InvalidResponseException):
         attiny.alive()
 
-    assert serial.received == b'\x01'
+    assert serial.received == ALIVE
     
 # flake8: noqa

--- a/tests/test_Serial.py
+++ b/tests/test_Serial.py
@@ -162,4 +162,28 @@ def test_set_both_motors_zero():
     
     assert result == True
     
+def test_set_both_motors_nak():
+    serial = MockSerial(NAK)
+    
+    attiny = AttinyProtocol(serial)
+    result = attiny.set_motors(0, 0)
+    
+    assert result == False
+    
+def test_set_both_motors_timeout():
+    serial = MockSerial(b'')
+    
+    attiny = AttinyProtocol(serial)
+    result = attiny.set_motors(0, 0)
+    
+    assert result == False
+    
+def test_set_both_motors_invalid():
+    serial = MockSerial(INVALID_RESPONSE)
+    
+    attiny = AttinyProtocol(serial)
+    with pytest.raises(InvalidResponseException):
+        attiny.set_motors(0, 0)
+
+
 # flake8: noqa

--- a/tests/test_Serial.py
+++ b/tests/test_Serial.py
@@ -8,6 +8,10 @@ ENCODERS_RIGHT = b'\x02'
 ENCODERS_LEFT = b'\x03'
 ENCODERS_BOTH = b'\x04'
 
+ENCODERS_RESET_RIGHT = b'\x05'
+ENCODERS_RESET_LEFT = b'\x06'
+ENCODERS_RESET_BOTH = b'\x07'
+
 ACK = b'\x10'
 NAK = b'\x14'
 
@@ -20,9 +24,9 @@ MOTOR_MAX = 127
 MOTOR_ZERO = 0
 
 # as signed byte values:
-BYTES_MOTOR_MIN = MOTOR_MIN.to_bytes(1, 'little', signed=True)
-BYTES_MOTOR_MAX = MOTOR_MAX.to_bytes(1, 'little', signed=True)
-BYTES_MOTOR_ZERO = MOTOR_ZERO.to_bytes(1, 'little', signed=True)
+BYTES_MOTOR_MIN = MOTOR_MIN.to_bytes(1, 'big', signed=True)
+BYTES_MOTOR_MAX = MOTOR_MAX.to_bytes(1, 'big', signed=True)
+BYTES_MOTOR_ZERO = MOTOR_ZERO.to_bytes(1, 'big', signed=True)
 
 INVALID_RESPONSE = b'\x23'
 
@@ -46,7 +50,7 @@ class MockSerial:
 
 def test_get_encoders():
     left, right = 0, 65535
-    encoder_bytes = left.to_bytes(2, 'little') + right.to_bytes(2, 'little')
+    encoder_bytes = left.to_bytes(2, 'big') + right.to_bytes(2, 'big')
     serial = MockSerial(encoder_bytes)
     
     attiny = AttinyProtocol(serial)
@@ -67,7 +71,7 @@ def test_get_encoders():
     
 def test_get_left_encoder():
     value = 43690
-    encoder_bytes = value.to_bytes(2, 'little')
+    encoder_bytes = value.to_bytes(2, 'big')
     serial = MockSerial(encoder_bytes)
     
     attiny = AttinyProtocol(serial)
@@ -78,7 +82,7 @@ def test_get_left_encoder():
     
 def test_get_right_encoder():
     value = 21845
-    encoder_bytes = value.to_bytes(2, 'little')
+    encoder_bytes = value.to_bytes(2, 'big')
     serial = MockSerial(encoder_bytes)
     
     attiny = AttinyProtocol(serial)
@@ -407,4 +411,5 @@ def test_set_both_motors_invalid():
     attiny = AttinyProtocol(serial)
     with pytest.raises(InvalidResponseException):
         attiny.set_motors(0, 0)
+
 # flake8: noqa

--- a/tests/test_Serial.py
+++ b/tests/test_Serial.py
@@ -1,4 +1,6 @@
-from raspibot.Serial import AttinyProtocol
+from raspibot.Serial import AttinyProtocol, InvalidResponseException
+
+import pytest
 
 
 class MockSerial:
@@ -62,7 +64,7 @@ def test_get_right_encoder():
     assert serial.received == b'\x02'
     assert result == value
     
-def test_alive():
+def test_alive_ack():
     # send out an ACK byte
     serial = MockSerial(b'\x10')
     
@@ -71,5 +73,25 @@ def test_alive():
     
     assert serial.received == b'\x01'
     assert result == True
+    
+def test_alive_nak():
+    # send out an NAK byte
+    serial = MockSerial(b'\x14')
+    
+    attiny = AttinyProtocol(serial)
+    result = attiny.alive()
+    
+    assert serial.received == b'\x01'
+    assert result == False
+    
+def test_alive_undefined():
+    # send out something that is neither an ACK or a NAK byte
+    serial = MockSerial(b'\x23')
+    
+    attiny = AttinyProtocol(serial)
+    with pytest.raises(InvalidResponseException):
+        attiny.alive()
+
+    assert serial.received == b'\x01'
     
 # flake8: noqa


### PR DESCRIPTION
Adds a class with methods and tests for all serial commands available in the current version of the ATtiny firmware.

- alive check and echo response
- motor control: set speed & stop
- encoder query & reset
- buzzer control: play frequency & stop
- set parameters for PI motor controller